### PR TITLE
Error in error throw's redirect target

### DIFF
--- a/ch09/lib/handlers.js
+++ b/ch09/lib/handlers.js
@@ -55,7 +55,7 @@ exports.newsletterSignupProcess = (req, res) => {
         intro: 'Database error!',
         message: 'There was a database error; please try again later.',
       }
-      return res.redirect(303, '/newsletter-archive')
+      return res.redirect(303, '/newsletter-signup')
     })
 }
 exports.newsletterSignupThankYou = (req, res) => res.render('newsletter-signup-thank-you')


### PR DESCRIPTION
Data base error redirects to '/newspaper-archive' which loads the thank you page as the meadowbank.js file has line - app.get('/newsletter-archive', handlers.newsletterSignupThankYou) I think the error throw is probaly supposed to reload the form page to give user another opertunity to submit, rather than the redirect to archive page, but either way probs not best to end up at a thank you page on error.